### PR TITLE
feat: add login helpers

### DIFF
--- a/src/main/java/com/biblio/controller/LoginController.java
+++ b/src/main/java/com/biblio/controller/LoginController.java
@@ -7,19 +7,54 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.stage.Stage;
+import java.util.prefs.Preferences;
 
 public class LoginController {
     @FXML private TextField userField;
     @FXML private PasswordField passField;
+    @FXML private TextField passFieldText;
+    @FXML private CheckBox rememberCheck;
+    @FXML private CheckBox showPassCheck;
     @FXML private Label msgLabel;
 
     private final UsuarioDAO usuarioDAO = new UsuarioDAO();
+    private final Preferences prefs = Preferences.userNodeForPackage(LoginController.class);
+
+    @FXML
+    public void initialize() {
+        passFieldText.textProperty().bindBidirectional(passField.textProperty());
+
+        showPassCheck.selectedProperty().addListener((obs, oldVal, newVal) -> {
+            if (newVal) {
+                passFieldText.setVisible(true);
+                passFieldText.setManaged(true);
+                passField.setVisible(false);
+                passField.setManaged(false);
+            } else {
+                passFieldText.setVisible(false);
+                passFieldText.setManaged(false);
+                passField.setVisible(true);
+                passField.setManaged(true);
+            }
+        });
+
+        String savedUser = prefs.get("savedUser", "");
+        if (!savedUser.isEmpty()) {
+            userField.setText(savedUser);
+            rememberCheck.setSelected(true);
+        }
+    }
 
     @FXML
     public void login(ActionEvent e) {
         try {
             String u = userField.getText().trim();
             String p = passField.getText().trim();
+            if (rememberCheck.isSelected()) {
+                prefs.put("savedUser", u);
+            } else {
+                prefs.remove("savedUser");
+            }
             if (usuarioDAO.validar(u, p)) {
                 Stage st = (Stage) userField.getScene().getWindow();
                 FXMLLoader loader = new FXMLLoader(getClass().getResource("/fxml/main.fxml"));

--- a/src/main/resources/fxml/login.fxml
+++ b/src/main/resources/fxml/login.fxml
@@ -15,8 +15,15 @@
                 <Label text="Usuario:" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
                 <TextField fx:id="userField" promptText="admin" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
                 <Label text="Contraseña:" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
-                <PasswordField fx:id="passField" promptText="admin" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
+                <StackPane GridPane.rowIndex="1" GridPane.columnIndex="1">
+                    <PasswordField fx:id="passField" promptText="admin"/>
+                    <TextField fx:id="passFieldText" promptText="admin" visible="false" managed="false"/>
+                </StackPane>
             </GridPane>
+            <HBox spacing="8">
+                <CheckBox fx:id="rememberCheck" text="Recordar usuario"/>
+                <CheckBox fx:id="showPassCheck" text="Mostrar contraseña"/>
+            </HBox>
             <Button text="Ingresar" onAction="#login"/>
             <Label fx:id="msgLabel" styleClass="msg"/>
         </VBox>


### PR DESCRIPTION
## Summary
- overlay a text field to show password and add checkboxes for remembering user and toggling visibility on the login screen
- persist chosen username via Preferences and toggle between hidden/visible password fields in controller

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d4807c7c833395002bb1f2a95030