### PR TITLE
Enable login via Enter key

### DIFF
--- a/src/main/resources/fxml/login.fxml
+++ b/src/main/resources/fxml/login.fxml
@@ -13,11 +13,11 @@
             <GridPane hgap="8" vgap="8">
                 <padding><Insets topRightBottomLeft="10"/></padding>
                 <Label text="Usuario:" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
-                <TextField fx:id="userField" promptText="admin" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
+                <TextField fx:id="userField" promptText="admin" GridPane.rowIndex="0" GridPane.columnIndex="1" onAction="#login"/>
                 <Label text="Contraseña:" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
-                <PasswordField fx:id="passField" promptText="admin" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
+                <PasswordField fx:id="passField" promptText="admin" GridPane.rowIndex="1" GridPane.columnIndex="1" onAction="#login"/>
             </GridPane>
-            <Button text="Ingresar" onAction="#login"/>
+            <Button text="Ingresar" onAction="#login" defaultButton="true"/>
             <Label fx:id="msgLabel" styleClass="msg"/>
         </VBox>
     </center>


### PR DESCRIPTION
## Summary
- Allow Enter key to trigger login by setting text fields' actions and making the login button default.

## Testing
- `mvn -q test` *(fails: Plugin resolution error; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d48700088333a147d8f6ef4314a1