### PR TITLE
Center login VBox and limit width

### DIFF
--- a/src/main/resources/fxml/login.fxml
+++ b/src/main/resources/fxml/login.fxml
@@ -6,7 +6,7 @@
 
 <StackPane styleClass="root" stylesheets="@../css/style.css" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.biblio.controller.LoginController">
     <children>
-        <VBox alignment="CENTER" spacing="12">
+        <VBox alignment="CENTER" spacing="12" StackPane.alignment="CENTER" maxWidth="360">
             <ImageView fx:id="logoView" fitHeight="250.0" fitWidth="1.0" preserveRatio="true" />
             <Label styleClass="login-title" text="Bienvenido a Biblio" />
             <VBox alignment="CENTER" spacing="12" styleClass="login-box">


### PR DESCRIPTION
## Summary
- Centered the login form's outer VBox within the StackPane and capped its width to improve layout responsiveness.
- Reviewed CSS `login-box` style to confirm it does not impose excessive widths.

## Testing
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c657040c8333884ac5702ef24bed