### PR TITLE
Fix ImageView width in login screen

### DIFF
--- a/src/main/resources/fxml/login.fxml
+++ b/src/main/resources/fxml/login.fxml
@@ -7,7 +7,7 @@
 <StackPane styleClass="root" stylesheets="@../css/style.css" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.biblio.controller.LoginController">
     <children>
         <VBox alignment="CENTER" spacing="12">
-            <ImageView fx:id="logoView" fitHeight="250.0" fitWidth="1.0" preserveRatio="true" />
+            <ImageView fx:id="logoView" fitHeight="250.0" fitWidth="250.0" preserveRatio="true" />
             <Label styleClass="login-title" text="Bienvenido a Biblio" />
             <VBox alignment="CENTER" spacing="12" styleClass="login-box">
                 <GridPane hgap="8" vgap="8">


### PR DESCRIPTION
## Summary
- Use a fixed width for the login screen logo to avoid scaling issues

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c66262388333a05bbdd709517a2a