### PR TITLE
Añadir opción de mostrar contraseña y botón salir en login

### DIFF
--- a/src/main/java/com/biblio/controller/LoginController.java
+++ b/src/main/java/com/biblio/controller/LoginController.java
@@ -7,6 +7,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.layout.GridPane;
 import javafx.stage.Stage;
 
 import java.net.URL;
@@ -15,8 +16,11 @@ public class LoginController {
 
     @FXML private TextField userField;
     @FXML private PasswordField passField;
+    private TextField passText;
+    @FXML private CheckBox showPassChk;
     @FXML private Label msgLabel;
     @FXML private ImageView logoView;
+    @FXML private Button btnSalir;
 
     @FXML
     private void initialize() {
@@ -32,6 +36,28 @@ public class LoginController {
         } else {
             System.err.println("No se encontró /images/logo.png en el classpath");
         }
+
+        // Campo alterno para mostrar texto plano de la contraseña
+        passText = new TextField();
+        passText.setManaged(false);
+        passText.setVisible(false);
+        passText.textProperty().bindBidirectional(passField.textProperty());
+        ((GridPane) passField.getParent()).add(passText, 1, 1);
+
+        // Conmutar visibilidad de los campos según el checkbox
+        showPassChk.selectedProperty().addListener((obs, oldVal, selected) -> {
+            if (selected) {
+                passText.setManaged(true);
+                passText.setVisible(true);
+                passField.setManaged(false);
+                passField.setVisible(false);
+            } else {
+                passText.setManaged(false);
+                passText.setVisible(false);
+                passField.setManaged(true);
+                passField.setVisible(true);
+            }
+        });
 
         // Mensaje inicial opcional
         // msgLabel.setText("");
@@ -57,5 +83,10 @@ public class LoginController {
             msgLabel.setText("Error: " + ex.getMessage());
             ex.printStackTrace();
         }
+    }
+
+    @FXML
+    private void salir() {
+        ((Stage) btnSalir.getScene().getWindow()).close();
     }
 }

--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -147,3 +147,16 @@
     -fx-background-radius: 8;
     -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 10, 0, 0, 2);
 }
+
+/* ===== Login extras ===== */
+.check-box {
+    -fx-text-fill: #2b2f36;
+}
+
+#btnSalir {
+    -fx-background-color: linear-gradient(to bottom, #e57373, #d32f2f);
+}
+
+#btnSalir:hover {
+    -fx-background-color: linear-gradient(to bottom, #ef9a9a, #e53935);
+}

--- a/src/main/resources/fxml/login.fxml
+++ b/src/main/resources/fxml/login.fxml
@@ -24,7 +24,11 @@
                   <RowConstraints />
                </rowConstraints>
                 </GridPane>
-                <Button onAction="#login" text="Ingresar" />
+                <CheckBox fx:id="showPassChk" text="Mostrar contraseña" />
+                <HBox alignment="CENTER" spacing="8">
+                    <Button onAction="#login" text="Ingresar" />
+                    <Button fx:id="btnSalir" onAction="#salir" text="Salir" />
+                </HBox>
                 <Label fx:id="msgLabel" styleClass="msg" />
             </VBox>
         </VBox>


### PR DESCRIPTION
## Summary
- Agrega checkbox para mostrar la contraseña y botón de salida en la vista de login.
- Implementa campo alterno de texto y conmutación según el checkbox, además de handler para cerrar la ventana.
- Añade estilos para el nuevo checkbox y botón de salida.

## Testing
- `mvn -q test` *(falla: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c66b1c0083338282c87f47982ca0