### PR TITLE
Validate student data before registration

### DIFF
--- a/src/main/java/com/biblio/controller/RegistrarVisitaController.java
+++ b/src/main/java/com/biblio/controller/RegistrarVisitaController.java
@@ -18,9 +18,9 @@ import java.time.LocalTime;
 
 public class RegistrarVisitaController {
 
-    @FXML private TextField numControlField, nombreField, generoField, carreraField, grupoField, obsField;
+    @FXML private TextField numControlField, nombreField, grupoField, obsField;
+    @FXML private ComboBox<String> generoCombo, carreraCombo, pcCombo;
     @FXML private CheckBox servPcCheck, consultaSalaCheck, lecturaSalaCheck, trabajoPersonalCheck, trabajoEquipoCheck;
-    @FXML private ComboBox<String> pcCombo;
     @FXML private Label altaMsg, regMsg;
 
     private final EstudianteDAO estudianteDAO = new EstudianteDAO();
@@ -38,13 +38,53 @@ public class RegistrarVisitaController {
     }
 
     @FXML
-    public void altaRapida() {
+    public void buscarEstudiante() {
+        try {
+            Estudiante e = estudianteDAO.findByNumControl(numControlField.getText().trim());
+            if (e != null) {
+                nombreField.setText(e.getNombre());
+                generoCombo.setValue(e.getGenero());
+                carreraCombo.setValue(e.getCarrera());
+                nombreField.setDisable(true);
+                generoCombo.setDisable(true);
+                carreraCombo.setDisable(true);
+                altaMsg.setText("Estudiante encontrado.");
+            } else {
+                nombreField.clear();
+                generoCombo.getSelectionModel().clearSelection();
+                carreraCombo.getSelectionModel().clearSelection();
+                nombreField.setDisable(false);
+                generoCombo.setDisable(false);
+                carreraCombo.setDisable(false);
+                altaMsg.setText("Nuevo estudiante.");
+            }
+        } catch (Exception ex) {
+            altaMsg.setText("Error: " + ex.getMessage());
+            ex.printStackTrace();
+        }
+    }
+
+    @FXML
+    public void guardarEstudiante() {
         try {
             String nc = numControlField.getText().trim();
-            String nom = nombreField.getText().trim();
-            Estudiante e = estudianteDAO.upsertRapido(nc, nom,
-                    generoField.getText().trim(), carreraField.getText().trim());
+            String nombre = nombreField.getText().trim();
+            String genero = generoCombo.getValue();
+            String carrera = carreraCombo.getValue();
+
+            if (nombre.isEmpty() || genero == null || carrera == null) {
+                altaMsg.setText("Capture nombre, género y carrera.");
+                return;
+            }
+
+            if (estudianteDAO.findByNumControl(nc) != null) {
+                altaMsg.setText("Ya existe un estudiante con ese número de control.");
+                return;
+            }
+
+            Estudiante e = estudianteDAO.upsertRapido(nc, nombre, genero, carrera);
             altaMsg.setText("OK: " + e.getNombre() + " [" + e.getNumControl() + "]");
+            buscarEstudiante();
         } catch (Exception e) {
             altaMsg.setText("Error: " + e.getMessage());
             e.printStackTrace();

--- a/src/main/resources/fxml/tab_registrar.fxml
+++ b/src/main/resources/fxml/tab_registrar.fxml
@@ -14,9 +14,9 @@
                 <padding><Insets topRightBottomLeft="10"/></padding>
                 <TextField fx:id="numControlField" promptText="Num. control"/>
                 <TextField fx:id="nombreField" promptText="Nombre"/>
-                <TextField fx:id="generoField" promptText="Género"/>
-                <TextField fx:id="carreraField" promptText="Carrera"/>
-                <Button text="Guardar/Usar" onAction="#altaRapida"/>
+                <ComboBox fx:id="generoCombo" promptText="Género"/>
+                <ComboBox fx:id="carreraCombo" promptText="Carrera"/>
+                <Button text="Guardar/Usar" onAction="#guardarEstudiante"/>
                 <Label fx:id="altaMsg"/>
             </HBox>
         </content>


### PR DESCRIPTION
## Summary
- add `guardarEstudiante` flow to validate required fields and check for existing records
- include `buscarEstudiante` to show saved data and disable fields to prevent duplicates
- switch registrar form to use gender/career combo boxes

## Testing
- `bash mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d5a3cf5c8333840edd609aca347c